### PR TITLE
feat(core): ensure php8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
         "yiisoft/yii2": "^2.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.8",
-        "phpunit/phpunit": "^7",
-        "bower-asset/chart-js": "^2.7"
+        "squizlabs/php_codesniffer": "^3.5",
+        "bower-asset/chart-js": "^2.7",
+        "symfony/phpunit-bridge": "^5.2"
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "simple-phpunit",
         "lint": "phpcs --standard=psr2 src tests",
         "beautify": "phpcbf --standard=psr2 src test",
         "pre-commit": [

--- a/tests/ChartTest.php
+++ b/tests/ChartTest.php
@@ -73,8 +73,8 @@ class ChartTest extends BaseTestCase
         $view = Yii::$app->getView();
         $js = end($view->js[View::POS_READY]);
 
-        $this->assertContains('"labels":["Key 1","Key 2"]', $js);
-        $this->assertContains('"data":[10,20]', $js);
+        $this->assertStringContainsString('"labels":["Key 1","Key 2"]', $js);
+        $this->assertStringContainsString('"data":[10,20]', $js);
     }
 
     /**
@@ -102,7 +102,7 @@ class ChartTest extends BaseTestCase
         $view = Yii::$app->getView();
         $js = end($view->js[View::POS_READY]);
 
-        $this->assertContains('window.MyChart = new Chart(', $js);
+        $this->assertStringContainsString('window.MyChart = new Chart(', $js);
     }
 
     /**
@@ -127,7 +127,7 @@ class ChartTest extends BaseTestCase
         $view = Yii::$app->getView();
         $js = end($view->js[View::POS_READY]);
 
-        $this->assertContains('"type":"scatter"', $js);
-        $this->assertContains('"data":[{"x":10,"y":10},{"x":20,"y":20}]', $js);
+        $this->assertStringContainsString('"type":"scatter"', $js);
+        $this->assertStringContainsString('"data":[{"x":10,"y":10},{"x":20,"y":20}]', $js);
     }
 }


### PR DESCRIPTION
This is all on the tests side. Updates codesniffer and moves to symfony phpunit
bridge so we can maintain 7.1 to 8.0

I think its worth noting I have not tested this on <7.1 (don't really think we want to support that anyway). The tests use `void` return type, so we can't test it.